### PR TITLE
[eXo Maven Rules] Update add-on to be eXo compatible

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,6 @@
 
     <dependencyManagement>
         <dependencies>
-
             <!-- Import versions from platform project -->
             <dependency>
                 <groupId>org.exoplatform.platform</groupId>
@@ -50,7 +49,6 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-
         </dependencies>
     </dependencyManagement>
 </project>


### PR DESCRIPTION
The main goal of this PR is to refactor the actual code regarding to Maven Rules so that this add-on can be released:
- [ ] Use the `addons-parent-pom` in _`<version>6</version>`_ for targeting eXo Platform 4.3.x and version _`<version>7-M01</version>`_ for targeting eXo Platfiorm 4.4.x
- [ ] Define the `groupId` of your addon like this  `org.exoplatform.addons.<project-git-name>` 
  - in your case, it will be `org.exoplatform.addons.import-users-csv`
- [ ] prefix all your `artifactIds` by the latest part of your `groupId`
  - in you case it could be `import-users-csv-*` (`import-users-csv-services`...)
- [ ] Maven _modules names_
  - [ ] Do not use _uppercase letters_ in Maven module names 
  - [ ] USe dash `-` to separate words in module name (ie: `my-module-name` )
  - [ ] Do not prefix Maven module names by `exo-addons`
- [ ] _Folders names_
  - [ ] Use the basic eXo rules if your artifactId are too long
    
    ```
    * addon-name
        * packaging
        * services
        * webapps
        - pom.xml
    ```
  - [ ] _OR_ name the folders like the artifactIds
    
    ```
    * import-users-csv
        * import-users-csv-packaging
        * import-users-csv-services
        * import-users-csv-webapps
        - pom.xml
    ```
  - [ ] Dependencies
  - [ ] Declare all Dependencies versions as _Maven properties_ in the reactor pom (parent pom) 
  - [ ] Use eXo BOMs as _dependencyManagement_ to add eXo dependencies
  - [ ] Run `mvn -Pformat-pom` to format all pom.xml files with eXo Rules in one command before committing POMs
